### PR TITLE
Fix duplicated text

### DIFF
--- a/src/articles/article6.qmd
+++ b/src/articles/article6.qmd
@@ -16,8 +16,7 @@
    a. The Budget Committee will work with the treasurer to create a budget to be submitted to the chapter.
 1. The Treasurer will submit the final budget proposal, as approved by the Budget Committee, for the following academic year to the chapter no later than three weeks before the beginning of the Fall Semester. The proposal must be approved by a {{< var glossary.supermajority >}} vote of the chapter.
    a. Following approval by the chapter, the budget proposal will be presented to CAB.
-1. Any officer with a budget may distribute portions of their budget as they see fit. 5. {{< var glossary.safety-margin >}} and Emergency Fund
-   a. Any money leftover for the year from the {{< var glossary.safety-margin >}} must be moved to an emergency fund account until that account has 50% of the next year's projected expenses saved. This account is only to be accessed with the vote of Executive Council ({{< var acronyms.ec >}}) and the Chapter Advisory Board ({{< var acronyms.cab >}}).
+1. Any officer with a budget may distribute portions of their budget as they see fit. 
 1. Safety Margin and Emergency Fund
    a. Any money leftover for the year from the Safety Margin must be moved to an emergency fund account until that account has 50% of the next year's projected expenses saved. This account is only to be accessed with the vote of Executive Council ({{< var acronyms.ec >}}) and the Chapter Advisory Board ({{< var acronyms.cab >}}).
 

--- a/src/articles/article6.qmd
+++ b/src/articles/article6.qmd
@@ -16,10 +16,9 @@
    a. The Budget Committee will work with the treasurer to create a budget to be submitted to the chapter.
 1. The Treasurer will submit the final budget proposal, as approved by the Budget Committee, for the following academic year to the chapter no later than three weeks before the beginning of the Fall Semester. The proposal must be approved by a {{< var glossary.supermajority >}} vote of the chapter.
    a. Following approval by the chapter, the budget proposal will be presented to CAB.
-1. Any officer with a budget may distribute portions of their budget as they see fit. 
-1. Safety Margin and Emergency Fund
-   a. Any money leftover for the year from the Safety Margin must be moved to an emergency fund account until that account has 50% of the next year's projected expenses saved. This account is only to be accessed with the vote of Executive Council ({{< var acronyms.ec >}}) and the Chapter Advisory Board ({{< var acronyms.cab >}}).
-
+1. Any officer with a budget may distribute portions of their budget as they see fit.
+1. {{< var glossary.safety-margin >}} and Emergency Fund
+   a. Any money leftover for the year from the {{< var glossary.safety-margin >}} must be moved to an emergency fund account until that account has 50% of the next year's projected expenses saved. This account is only to be accessed with the vote of Executive Council ({{< var acronyms.ec >}}) and the Chapter Advisory Board ({{< var acronyms.cab >}}).
 
 ## Financial Obligations of Members {#sec-art-VDN0D2P4}
 


### PR DESCRIPTION
Removes duplicated text about the safety margin. 

I'd guess this was accidentally left in from a previous version since the numbering is different.